### PR TITLE
Fix missing newline when appending to config/initializers/assets.rb

### DIFF
--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -47,22 +47,22 @@ module Spotlight
     end
 
     def assets
-      #create a nothumb directory for the nothumb theme 
+      #create a nothumb directory for the nothumb theme
       empty_directory 'app/assets/stylesheets/nothumb'
-      
+
       #use our modified application.css
-      copy_file 'application.css', 'app/assets/stylesheets/application.css' 
+      copy_file 'application.css', 'app/assets/stylesheets/application.css'
       copy_file 'application_nothumb.css', 'app/assets/stylesheets/application_nothumb.css'
       copy_file 'nothumb.scss', 'app/assets/stylesheets/nothumb/nothumb.scss'
       copy_file 'spotlight.scss', 'app/assets/stylesheets/spotlight.scss'
       copy_file 'harvard.css', 'app/assets/stylesheets/harvard.css'
       copy_file 'spotlight.js', 'app/assets/javascripts/spotlight.js'
     end
-    
+
     def add_theme_images
       empty_directory 'app/assets/images/spotlight/themes'
-      copy_file 'default_preview.png', 'app/assets/images/spotlight/themes/default_preview.png' 
-      copy_file 'nothumb_preview.png', 'app/assets/images/spotlight/themes/nothumb_preview.png' 
+      copy_file 'default_preview.png', 'app/assets/images/spotlight/themes/default_preview.png'
+      copy_file 'nothumb_preview.png', 'app/assets/images/spotlight/themes/nothumb_preview.png'
     end
 
     def add_roles_to_user
@@ -123,13 +123,13 @@ module Spotlight
       gem 'blacklight-oembed', '>= 0.1.0'
       generate 'blacklight_oembed:install'
     end
-    
+
     def update_catalog_controller
       gsub_file('app/controllers/catalog_controller.rb', /:openseadragon/, ':viewer')
     end
-    
+
     def update_assets_initializer
-      append_to_file('config/initializers/assets.rb', 'Rails.application.config.assets.precompile += %w( application_nothumb.css )')
+      append_to_file('config/initializers/assets.rb', "Rails.application.config.assets.precompile += %w( application_nothumb.css )\n")
     end
 
     def add_mailer_defaults
@@ -163,7 +163,7 @@ module Spotlight
     def add_translations
       copy_file 'config/initializers/translation.rb'
     end
-    
+
     #Inserts a file to join multiple values by a <br> instead of a comma
     def add_join
       copy_file 'join.rb', 'app/presenters/blacklight/rendering/join.rb'


### PR DESCRIPTION
Without this fix, the last two lines run together as
`Rails.application.config.assets.precompile += %w(
application_nothumb.css )Rails.application.config.assets.precompile +=
%w( application_modern.css )`, and `rake spotlight:server` fails.

(Sorry for the whitespace noise; I can re-push if needed. Text editor gets rid of it automatically.)